### PR TITLE
Fix fatal typo in options file

### DIFF
--- a/options.json
+++ b/options.json
@@ -5,6 +5,6 @@
   "conferenceNumber": "+1-number-from-bandwidth",
   "domain": "callback-url-for-this-app(E.g.: 'abcdefg.ngrok.io', in this exact format, without 'http://' or ending '/'",
   "caller": "+1-number-from-bandwidth(you can use same number with conference_number)",
-  "bridgeCallee": "+1-number-which-can-receive-a-call"
+  "bridgeCallee": "+1-number-which-can-receive-a-call",
   "sipDomain": "sip-domain-from-your-bandwidth-account"
 }


### PR DESCRIPTION
The options file is malformed JSON at the moment. Apps will not start. Although the options should be changed by the user, having the application throw an error on first run is a bit disconcerting when first approaching the examples.